### PR TITLE
parse persistent id of created dataset

### DIFF
--- a/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
+++ b/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
@@ -73,6 +73,7 @@ public class DatasetOperationsTest extends AbstractIntegrationTest {
 		// create Dataset in child dataverse
 		Identifier datasetId = dataverseOps.createDataset(facade, newDV.getAlias());
 		assertNotNull(datasetId.getId());
+		assertNotNull(datasetId.getPersistentId());
 		Dataset ds = datasetOps.getDataset(datasetId);
 		String doiId = ds.getDoiId().get();
 		datasetOps.uploadFile(doiId, getTestFile());

--- a/src/main/java/com/researchspace/dataverse/entities/Identifier.java
+++ b/src/main/java/com/researchspace/dataverse/entities/Identifier.java
@@ -28,5 +28,6 @@ Copyright 2016 ResearchSpace
 @NoArgsConstructor
 public class Identifier {
 	private Long id;
+	private String persistentId;
 
 }

--- a/src/main/java/com/researchspace/dataverse/entities/facade/DatasetFacade.java
+++ b/src/main/java/com/researchspace/dataverse/entities/facade/DatasetFacade.java
@@ -3,17 +3,12 @@
  */
 package com.researchspace.dataverse.entities.facade;
 
+import lombok.*;
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Singular;
 /**
  * /** <pre>
 Copyright 2016 ResearchSpace


### PR DESCRIPTION
@AleixMT Thanks for the curl snippet re #14 
 Here is proposed fix. The created dataset in the test contains non-null persistent identifier.