### PR TITLE
Native file upload #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Significant changes since 0.1.0
 
+1.1.0 In progress
+
+- feature: Support upload of files to a dataset using native API. #16
+- feature: After creating a Dataset, the persistent ID is stored in the Identifier object. #22
+
 1.0.0 2022-11-21
 
 Increasing major version due to major updates to dependencies. However, there are no
@@ -8,7 +13,7 @@ breaking API changes in this library.
 - dependencies: Major dependency updates to Spring 5.3, Lombok 18.24. 
 - build: fix integration tests
 - build: enable integration test running through Github actions
-- build: test build and test on Java 8, 11, and 17
+- build: test build and test on Java 8, 11, and 17.
 
 0.2.0 2022-11-20
 

--- a/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
+++ b/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.researchspace.dataverse.entities.facade.DatasetTestFactory.createFacade;
@@ -66,7 +67,9 @@ public class DatasetOperationsTest extends AbstractIntegrationTest {
 		DatasetFacade facade = createFacade();
 		Identifier datasetId = dataverseOps.createDataset(facade, dataverseAlias);
 		assertNotNull(datasetId.getId());
-		DatasetFileList datasetFileList = datasetOps.uploadNativeFile(datasetId, new byte[]{1, 2, 3, 4, 5}, "myFileName.dat");
+		FileUploadMetadata meta = FileUploadMetadata.builder().description("My description.").categories(Arrays.asList(new String[]{"Data"}))
+				.directoryLabel("test/x").build();
+		DatasetFileList datasetFileList = datasetOps.uploadNativeFile(meta, datasetId, new byte[]{1, 2, 3, 4, 5}, "myFileName.dat");
 		assertNotNull(datasetFileList);
 		assertEquals(1, datasetFileList.getFiles().size());
 		assertTrue(datasetFileList.getFiles().get(0).getCategories().contains("Data"));

--- a/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
+++ b/src/integration-test/java/com/researchspace/dataverse/http/DatasetOperationsTest.java
@@ -59,7 +59,18 @@ public class DatasetOperationsTest extends AbstractIntegrationTest {
 		String toPost = FileUtils.readFileToString(exampleDatasetJson);
 		Identifier datasetId = dataverseOps.createDataset(toPost, dataverseAlias);
 		assertNotNull(datasetId.getId());
+	}
 
+	@Test
+	public void uploadFileToDataSetWithNativeApi() throws IOException, URISyntaxException {
+		DatasetFacade facade = createFacade();
+		Identifier datasetId = dataverseOps.createDataset(facade, dataverseAlias);
+		assertNotNull(datasetId.getId());
+		DatasetFileList datasetFileList = datasetOps.uploadNativeFile(datasetId, new byte[]{1, 2, 3, 4, 5}, "myFileName.dat");
+		assertNotNull(datasetFileList);
+		assertEquals(1, datasetFileList.getFiles().size());
+		assertTrue(datasetFileList.getFiles().get(0).getCategories().contains("Data"));
+		assertTrue(datasetFileList.getFiles().get(0).getDescription().equals(("My description.")));
 	}
 
 	@Test

--- a/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
+++ b/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
@@ -5,6 +5,7 @@ package com.researchspace.dataverse.api.v1;
 
 import com.researchspace.dataverse.entities.*;
 import com.researchspace.dataverse.entities.facade.DatasetFacade;
+import com.researchspace.dataverse.http.FileUploadMetadata;
 
 import java.io.File;
 import java.io.InputStream;
@@ -56,7 +57,7 @@ public interface DatasetOperations {
 	 */
 	List<DatasetVersion> getDatasetVersions(Identifier dsIdentifier);
 
-    DatasetFileList uploadNativeFile(Identifier dsIdentifier, byte[] data, String fileName);
+    DatasetFileList uploadNativeFile(FileUploadMetadata metadata, Identifier dsIdentifier, byte[] data, String fileName);
 
     /**
 	 * Uploads a file to a dataset

--- a/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
+++ b/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
@@ -42,7 +42,6 @@ public interface DatasetOperations {
 	 */
 	DatasetVersion updateDataset(DatasetFacade facade, Identifier id);
 
-    
 	/**
 	 * Retrieves a {@link Dataset} based on its Id.
 	 * @param dsIdentifier
@@ -57,7 +56,27 @@ public interface DatasetOperations {
 	 */
 	List<DatasetVersion> getDatasetVersions(Identifier dsIdentifier);
 
-    DatasetFileList uploadNativeFile(FileUploadMetadata metadata, Identifier dsIdentifier, byte[] data, String fileName);
+	/**
+	 * Upload a file to a dataset using Dataverse's native API (not Sword)
+	 * @param metadata Metadata to attach to the file upload
+	 * @param dsIdentifier The persistent identifier of the dataset
+	 * @param data bytes of data to upload
+	 * @param fileName The name of the file to be created on Dataverse
+	 * @return DatasetFileList information about the uploaded file.
+	 */
+    DatasetFileList uploadNativeFile( byte[] data, FileUploadMetadata metadata, Identifier dsIdentifier, String fileName);
+
+	/**
+	 * Upload a file to a dataset using Dataverse's native API (not Sword).
+	 * @param metadata Metadata to attach to the file upload
+	 * @param contentLength The length of the stream
+	 * @param dsIdentifier The persistent identifier of the dataset
+	 * @param data bytes of data to upload
+	 * @param fileName The name of the file to be created on Dataverse
+	 * @return DatasetFileList information about the uploaded file.
+	 */
+	DatasetFileList uploadNativeFile(InputStream data, long contentLength, FileUploadMetadata metadata,
+									 Identifier dsIdentifier,  String fileName);
 
     /**
 	 * Uploads a file to a dataset

--- a/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
+++ b/src/main/java/com/researchspace/dataverse/api/v1/DatasetOperations.java
@@ -3,19 +3,12 @@
  */
 package com.researchspace.dataverse.api.v1;
 
+import com.researchspace.dataverse.entities.*;
+import com.researchspace.dataverse.entities.facade.DatasetFacade;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
-
-import com.researchspace.dataverse.entities.DataSetMetadataBlock;
-import com.researchspace.dataverse.entities.Dataset;
-import com.researchspace.dataverse.entities.DatasetVersion;
-import com.researchspace.dataverse.entities.DataverseResponse;
-import com.researchspace.dataverse.entities.DvMessage;
-import com.researchspace.dataverse.entities.Identifier;
-import com.researchspace.dataverse.entities.PublishedDataset;
-import com.researchspace.dataverse.entities.Version;
-import com.researchspace.dataverse.entities.facade.DatasetFacade;
 /**
 <pre>
   Copyright 2016 ResearchSpace
@@ -63,7 +56,9 @@ public interface DatasetOperations {
 	 */
 	List<DatasetVersion> getDatasetVersions(Identifier dsIdentifier);
 
-	/**
+    DatasetFileList uploadNativeFile(Identifier dsIdentifier, byte[] data, String fileName);
+
+    /**
 	 * Uploads a file to a dataset
 	 * @param doi The DOI of the  Dataset
 	 * @param file The file to add to the DataSet

--- a/src/main/java/com/researchspace/dataverse/entities/Checksum.java
+++ b/src/main/java/com/researchspace/dataverse/entities/Checksum.java
@@ -1,7 +1,12 @@
 package com.researchspace.dataverse.entities;
 
+import com.researchspace.dataverse.http.FileUploadMetadata;
 import lombok.Data;
 
+/**
+ * Checksum is part of the response from
+ * {@link com.researchspace.dataverse.api.v1.DatasetOperations#uploadNativeFile(byte[], FileUploadMetadata, Identifier, String)}
+ */
 @Data
 public class Checksum {
     private  String type;

--- a/src/main/java/com/researchspace/dataverse/entities/Checksum.java
+++ b/src/main/java/com/researchspace/dataverse/entities/Checksum.java
@@ -1,0 +1,9 @@
+package com.researchspace.dataverse.entities;
+
+import lombok.Data;
+
+@Data
+public class Checksum {
+    private  String type;
+    private  String value;
+}

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
@@ -1,0 +1,15 @@
+package com.researchspace.dataverse.entities;
+
+import java.util.List;
+
+public class DatasetFile {
+    private  String description;
+    private  String label;
+    private  String directoryLabel;
+    private  String datasetVersionId;
+    private List<String> categories;
+    private  boolean restricted;
+    private  int version;
+    private DatasetFileDetails dataFile;
+
+}

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
@@ -1,9 +1,14 @@
 package com.researchspace.dataverse.entities;
 
+import com.researchspace.dataverse.http.FileUploadMetadata;
 import lombok.Data;
 
 import java.util.List;
 
+/**
+ * DatasetFile is part of the response from
+ * {@link com.researchspace.dataverse.api.v1.DatasetOperations#uploadNativeFile(byte[], FileUploadMetadata, Identifier, String)}
+ */
 @Data
 public class DatasetFile {
     private  String description;

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFile.java
@@ -1,7 +1,10 @@
 package com.researchspace.dataverse.entities;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class DatasetFile {
     private  String description;
     private  String label;

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
@@ -1,9 +1,14 @@
 package com.researchspace.dataverse.entities;
 
+import com.researchspace.dataverse.http.FileUploadMetadata;
 import lombok.Data;
 
 import java.util.Date;
 
+/**
+ * DatasetFileDetails is a subsection of the response from
+ * {@link com.researchspace.dataverse.api.v1.DatasetOperations#uploadNativeFile(byte[], FileUploadMetadata, Identifier, String)}
+ */
 @Data
 public class DatasetFileDetails {
     private int id;

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
@@ -1,0 +1,21 @@
+package com.researchspace.dataverse.entities;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class DatasetFileDetails {
+    private int id;
+    private int filesize;
+    private String persistentId;
+    private String pidURL;
+    private String filename;
+    private String contentType;
+    private String description;
+    private String storageIdentifier;
+    private String rootDataFileId;
+    private String md5;
+    private Checksum checksum;
+    private LocalDate creationDate;
+}

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFileDetails.java
@@ -2,7 +2,7 @@ package com.researchspace.dataverse.entities;
 
 import lombok.Data;
 
-import java.time.LocalDate;
+import java.util.Date;
 
 @Data
 public class DatasetFileDetails {
@@ -17,5 +17,5 @@ public class DatasetFileDetails {
     private String rootDataFileId;
     private String md5;
     private Checksum checksum;
-    private LocalDate creationDate;
+    private Date creationDate;
 }

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFileList.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFileList.java
@@ -1,0 +1,10 @@
+package com.researchspace.dataverse.entities;
+
+import lombok.Data;
+
+import java.util.List;
+@Data
+public class DatasetFileList {
+    List<DatasetFile> files;
+}
+

--- a/src/main/java/com/researchspace/dataverse/entities/DatasetFileList.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DatasetFileList.java
@@ -3,6 +3,10 @@ package com.researchspace.dataverse.entities;
 import lombok.Data;
 
 import java.util.List;
+
+/**
+ * DatasetFileList is the response from uploading a file using the native API
+ */
 @Data
 public class DatasetFileList {
     List<DatasetFile> files;

--- a/src/main/java/com/researchspace/dataverse/entities/DataverseResponse.java
+++ b/src/main/java/com/researchspace/dataverse/entities/DataverseResponse.java
@@ -3,6 +3,7 @@
  */
 package com.researchspace.dataverse.entities;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 /**
  *  <pre>
@@ -30,6 +31,7 @@ public class DataverseResponse <T> {
 	
 	private String status;
 	private T data;
+	@JsonDeserialize(using = ObjectOrStringMessageDeserializer.class )
 	private String message;
 
 }

--- a/src/main/java/com/researchspace/dataverse/entities/ObjectOrStringMessageDeserializer.java
+++ b/src/main/java/com/researchspace/dataverse/entities/ObjectOrStringMessageDeserializer.java
@@ -21,7 +21,7 @@ public class ObjectOrStringMessageDeserializer extends JsonDeserializer<String> 
         } else if (node.isObject()){
             return node.get("message").toString();
         } else{
-            throw new IllegalArgumentException("expect a string or an object with a string property");
+            throw new IllegalArgumentException("expect a string or an object with a string property 'message'");
         }
 
     }

--- a/src/main/java/com/researchspace/dataverse/entities/ObjectOrStringMessageDeserializer.java
+++ b/src/main/java/com/researchspace/dataverse/entities/ObjectOrStringMessageDeserializer.java
@@ -1,0 +1,28 @@
+package com.researchspace.dataverse.entities;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * 'message' property can be a string or an object with property 'message'; this handles both
+ */
+public class ObjectOrStringMessageDeserializer extends JsonDeserializer<String> {
+    @Override
+    public String deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+
+        JsonNode node =  jp.getCodec().readTree((jp));
+        if (node.isTextual()){
+            return node.toString();
+        } else if (node.isObject()){
+            return node.get("message").toString();
+        } else{
+            throw new IllegalArgumentException("expect a string or an object with a string property");
+        }
+
+    }
+}

--- a/src/main/java/com/researchspace/dataverse/http/AbstractOpsImplV1.java
+++ b/src/main/java/com/researchspace/dataverse/http/AbstractOpsImplV1.java
@@ -3,8 +3,11 @@
  */
 package com.researchspace.dataverse.http;
 
-import java.util.Arrays;
-
+import com.researchspace.dataverse.api.v1.DataverseConfig;
+import com.researchspace.dataverse.entities.DataverseResponse;
+import com.researchspace.springrest.ext.LoggingResponseErrorHandler;
+import com.researchspace.springrest.ext.RestUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,12 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import com.researchspace.dataverse.api.v1.DataverseConfig;
-import com.researchspace.dataverse.entities.DataverseResponse;
-import com.researchspace.springrest.ext.LoggingResponseErrorHandler;
-import com.researchspace.springrest.ext.RestUtil;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.Arrays;
 
 /** <pre>
 Copyright 2016 ResearchSpace
@@ -101,8 +99,12 @@ public abstract class AbstractOpsImplV1 {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
 		headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
-		headers.add(apiHeader, apiKey);
+		addApiKey(headers);
 		return headers;
+	}
+
+	 void addApiKey(HttpHeaders headers) {
+		headers.add(apiHeader, apiKey);
 	}
 
 }

--- a/src/main/java/com/researchspace/dataverse/http/DataverseOperationsImplV1.java
+++ b/src/main/java/com/researchspace/dataverse/http/DataverseOperationsImplV1.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.swordapp.client.ProtocolViolationException;
 import org.swordapp.client.SWORDClientException;
@@ -190,11 +191,12 @@ public class DataverseOperationsImplV1 extends AbstractOpsImplV1 implements Data
 		return resp.getBody().getData();
 	}
 
-	public DatasetFileList uploadNativeFile(Identifier dsIdentifier){
-		String url = createV1Url("datasets", ":persistentId", "add") + "?persistentId=" + dsIdentifier.getId();
-		HttpEntity<String> entity = createHttpEntity("{}");
+	@Override
+	public DatasetFileList uploadNativeFile(Identifier dsIdentifier, byte[] data, String fileName){
+		String url = createV1Url("datasets", ":persistentId", "add") + "?persistentId=" + dsIdentifier.getPersistentId();
 		ParameterizedTypeReference<DataverseResponse<DatasetFileList>> type =
 				new ParameterizedTypeReference<DataverseResponse<DatasetFileList>>() {};
+		HttpEntity<MultiValueMap<String, Object>> entity = new NativeFileUploader().uploadFile(apiKey, data, fileName);
 		ResponseEntity<DataverseResponse<DatasetFileList>> resp = template.exchange(url, HttpMethod.POST, entity, type);
 		log.debug("{}", resp.getBody());
 		handleError(resp);

--- a/src/main/java/com/researchspace/dataverse/http/DataverseOperationsImplV1.java
+++ b/src/main/java/com/researchspace/dataverse/http/DataverseOperationsImplV1.java
@@ -192,11 +192,11 @@ public class DataverseOperationsImplV1 extends AbstractOpsImplV1 implements Data
 	}
 
 	@Override
-	public DatasetFileList uploadNativeFile(Identifier dsIdentifier, byte[] data, String fileName){
+	public DatasetFileList uploadNativeFile( FileUploadMetadata metadata, Identifier dsIdentifier, byte[] data, String fileName){
 		String url = createV1Url("datasets", ":persistentId", "add") + "?persistentId=" + dsIdentifier.getPersistentId();
 		ParameterizedTypeReference<DataverseResponse<DatasetFileList>> type =
 				new ParameterizedTypeReference<DataverseResponse<DatasetFileList>>() {};
-		HttpEntity<MultiValueMap<String, Object>> entity = new NativeFileUploader().uploadFile(apiKey, data, fileName);
+		HttpEntity<MultiValueMap<String, Object>> entity = new NativeFileUploader().uploadFile(metadata, apiKey, data, fileName);
 		ResponseEntity<DataverseResponse<DatasetFileList>> resp = template.exchange(url, HttpMethod.POST, entity, type);
 		log.debug("{}", resp.getBody());
 		handleError(resp);

--- a/src/main/java/com/researchspace/dataverse/http/FileUploadMetadata.java
+++ b/src/main/java/com/researchspace/dataverse/http/FileUploadMetadata.java
@@ -10,7 +10,6 @@ import java.util.List;
  */
 @Data
 @Builder
-
 public class FileUploadMetadata {
     private String description;
     private String directoryLabel;

--- a/src/main/java/com/researchspace/dataverse/http/FileUploadMetadata.java
+++ b/src/main/java/com/researchspace/dataverse/http/FileUploadMetadata.java
@@ -1,0 +1,21 @@
+package com.researchspace.dataverse.http;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Request object for metadata included with native file upload to an existing dataset
+ */
+@Data
+@Builder
+
+public class FileUploadMetadata {
+    private String description;
+    private String directoryLabel;
+    private List<String> categories;
+    private boolean restrict;
+    private boolean tabIngest;
+
+}

--- a/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
+++ b/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
@@ -1,0 +1,45 @@
+package com.researchspace.dataverse.http;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+public class NativeFileUploader {
+
+    public HttpEntity<MultiValueMap<String, Object>> uploadFile(String apiKey, byte [] data, String fName){
+        RestTemplate restTemplate = new RestTemplate();
+        MultiValueMap<String,Object> multipartRequest = new LinkedMultiValueMap<>();
+
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.add(AbstractOpsImplV1.apiHeader, apiKey);
+        requestHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);//Main request's headers
+
+        HttpHeaders requestHeadersAttachment = new HttpHeaders();
+        //requestHeadersAttachment.setContentType(MediaType.APPLICATION_OCTET_STREAM);// extract mediatype from file extensionHttpEntity<ByteArrayResource> attachmentPart;
+        ByteArrayResource fileAsResource = new ByteArrayResource(data){
+            @Override
+            public String getFilename(){
+                return fName;
+            }
+        };
+        HttpEntity attachmentPart = new HttpEntity<>(fileAsResource,requestHeadersAttachment);
+
+        multipartRequest.set("file",attachmentPart);
+
+
+        HttpHeaders requestHeadersJSON = new HttpHeaders();
+
+        requestHeadersJSON.setContentType(MediaType.APPLICATION_JSON);
+        String requestBody = "{\"description\":\"My description.\",\"directoryLabel\":\"data/subdir1\",\"categories\":[\"Data\"], \"restrict\":\"false\", \"tabIngest\":\"false\"}";
+        HttpEntity<String> requestEntityJSON = new HttpEntity<>(requestBody, requestHeadersJSON);
+
+        multipartRequest.set("jsonData",requestEntityJSON);
+
+        HttpEntity<MultiValueMap<String,Object>> requestEntity = new HttpEntity<>(multipartRequest,requestHeaders);//final request
+
+        return requestEntity;
+
+    }
+}

--- a/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
+++ b/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
@@ -1,15 +1,19 @@
 package com.researchspace.dataverse.http;
 
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.*;
+import org.springframework.core.io.AbstractResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
+/**
+ * NativeFileUploader is  helper class that performs upload of files using native API
+ */
 public class NativeFileUploader {
 
-    public HttpEntity<MultiValueMap<String, Object>> uploadFile(FileUploadMetadata metadata, String apiKey, byte[] data, String fName){
-        RestTemplate restTemplate = new RestTemplate();
+    public HttpEntity<MultiValueMap<String, Object>> createFileUploadEntity(FileUploadMetadata metadata, String apiKey, AbstractResource resource){
+
         MultiValueMap<String,Object> multipartRequest = new LinkedMultiValueMap<>();
 
         HttpHeaders requestHeaders = new HttpHeaders();
@@ -17,15 +21,8 @@ public class NativeFileUploader {
         requestHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);//Main request's headers
 
         HttpHeaders requestHeadersAttachment = new HttpHeaders();
-        //requestHeadersAttachment.setContentType(MediaType.APPLICATION_OCTET_STREAM);// extract mediatype from file extensionHttpEntity<ByteArrayResource> attachmentPart;
-        ByteArrayResource fileAsResource = new ByteArrayResource(data){
-            @Override
-            public String getFilename(){
-                return fName;
-            }
-        };
-        HttpEntity attachmentPart = new HttpEntity<>(fileAsResource,requestHeadersAttachment);
 
+        HttpEntity attachmentPart = new HttpEntity<>(resource,requestHeadersAttachment);
         multipartRequest.set("file",attachmentPart);
 
         HttpHeaders requestHeadersJSON = new HttpHeaders();

--- a/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
+++ b/src/main/java/com/researchspace/dataverse/http/NativeFileUploader.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestTemplate;
 
 public class NativeFileUploader {
 
-    public HttpEntity<MultiValueMap<String, Object>> uploadFile(String apiKey, byte [] data, String fName){
+    public HttpEntity<MultiValueMap<String, Object>> uploadFile(FileUploadMetadata metadata, String apiKey, byte[] data, String fName){
         RestTemplate restTemplate = new RestTemplate();
         MultiValueMap<String,Object> multipartRequest = new LinkedMultiValueMap<>();
 
@@ -28,17 +28,12 @@ public class NativeFileUploader {
 
         multipartRequest.set("file",attachmentPart);
 
-
         HttpHeaders requestHeadersJSON = new HttpHeaders();
-
         requestHeadersJSON.setContentType(MediaType.APPLICATION_JSON);
-        String requestBody = "{\"description\":\"My description.\",\"directoryLabel\":\"data/subdir1\",\"categories\":[\"Data\"], \"restrict\":\"false\", \"tabIngest\":\"false\"}";
-        HttpEntity<String> requestEntityJSON = new HttpEntity<>(requestBody, requestHeadersJSON);
-
+        HttpEntity<FileUploadMetadata> requestEntityJSON = new HttpEntity<>(metadata, requestHeadersJSON);
         multipartRequest.set("jsonData",requestEntityJSON);
 
         HttpEntity<MultiValueMap<String,Object>> requestEntity = new HttpEntity<>(multipartRequest,requestHeaders);//final request
-
         return requestEntity;
 
     }

--- a/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
+++ b/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
@@ -63,7 +63,7 @@ public class DatasetFilePostMockServerTest {
 		tss.configure(cfg);
 		Identifier id = new Identifier();
 		id.setId(1234L);
-		DatasetFileList resp = tss.uploadNativeFile(id);
+		DatasetFileList resp = tss.uploadNativeFile(id, null, null);
 		assertNotNull(resp.getFiles());
 		assertEquals(1, resp.getFiles().size());
 	}

--- a/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
+++ b/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
@@ -8,8 +8,6 @@ import com.researchspace.dataverse.entities.DatasetFileList;
 import com.researchspace.dataverse.entities.Identifier;
 import com.researchspace.dataverse.search.entities.SearchConfig;
 import com.researchspace.dataverse.testutils.TestFileUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.web.client.ExpectedCount;
@@ -43,27 +41,22 @@ Copyright 2016 ResearchSpace
 </pre>
 */
 public class DatasetFilePostMockServerTest {
-		
-	@Before
-	public void setUp() throws Exception {
-	}
 
-	@After
-	public void tearDown() throws Exception {
-	}
 
 	@Test
 	public void testNativeFilePost() throws MalformedURLException {
 		RestTemplate template = new RestTemplate();
 		DataverseOperationsImplV1 tss = setupDataverseOps(template);
-		setUpServerResponse(template, "http://anyDataverse.com/api/v1/datasets/:persistentId/add?persistentId=1234",
+		final String persistentid = "doi://dsfh.dsdsd.sds";
+		setUpServerResponse(template, "http://anyDataverse.com/api/v1/datasets/:persistentId/add?persistentId="+persistentid,
 				getDataSetFileUploadResults() );
 		
 		DataverseConfig cfg = new DataverseConfig(new URL("http://anyDataverse.com"), "any", "alias");
 		tss.configure(cfg);
 		Identifier id = new Identifier();
 		id.setId(1234L);
-		DatasetFileList resp = tss.uploadNativeFile( FileUploadMetadata.builder().build(), id, null, null);
+		id.setPersistentId(persistentid);
+		DatasetFileList resp = tss.uploadNativeFile(new byte []{}, FileUploadMetadata.builder().build(), id,  "any");
 		assertNotNull(resp.getFiles());
 		assertEquals(1, resp.getFiles().size());
 	}

--- a/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
+++ b/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
@@ -1,0 +1,104 @@
+/*
+ * 
+ */
+package com.researchspace.dataverse.http;
+
+import com.researchspace.dataverse.api.v1.DataverseConfig;
+import com.researchspace.dataverse.entities.DatasetFileList;
+import com.researchspace.dataverse.entities.Identifier;
+import com.researchspace.dataverse.search.entities.SearchConfig;
+import com.researchspace.dataverse.testutils.TestFileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+
+/** <pre>
+Copyright 2016 ResearchSpace
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+</pre>
+*/
+public class DatasetFilePostMockServerTest {
+		
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void testNativeFilePost() throws MalformedURLException {
+		RestTemplate template = new RestTemplate();
+		DataverseOperationsImplV1 tss = setupDataverseOps(template);
+		setUpServerResponse(template, "http://anyDataverse.com/api/v1/datasets/:persistentId/add?persistentId=1234",
+				getDataSetFileUploadResults() );
+		
+		DataverseConfig cfg = new DataverseConfig(new URL("http://anyDataverse.com"), "any", "alias");
+		tss.configure(cfg);
+		Identifier id = new Identifier();
+		id.setId(1234L);
+		DatasetFileList resp = tss.uploadNativeFile(id);
+		assertNotNull(resp.getFiles());
+		assertEquals(1, resp.getFiles().size());
+	}
+
+	private void setUpServerResponse(RestTemplate template, String url, String response) {
+		MockRestServiceServer server = MockRestServiceServer.bindTo(template).build();
+		server.expect(ExpectedCount.once(), MockRestRequestMatchers.requestTo(url))
+		 .andExpect(method(HttpMethod.POST))
+	     .andRespond(MockRestResponseCreators.withSuccess(response,
+	    		 APPLICATION_JSON));
+	}
+
+	DataverseOperationsImplV1  setUpDataset  (SearchConfig srchCfg, String url, GetJson expectedJsonGetter) throws MalformedURLException {
+		RestTemplate template = new RestTemplate();
+		DataverseOperationsImplV1 tss = setupDataverseOps(template);
+		setUpServerResponse(template, url, expectedJsonGetter.getJson() );		
+		DataverseConfig cfg = new DataverseConfig(new URL("http://anyDataverse.com"), "any", "alias");
+		tss.configure(cfg);	
+		return tss;
+	}
+
+	private DataverseOperationsImplV1 setupDataverseOps(RestTemplate template) {
+		DataverseOperationsImplV1 tss = new DataverseOperationsImplV1();
+		tss.setTemplate(template);
+		return tss;
+	}
+	
+	@FunctionalInterface
+	static interface GetJson {
+		String getJson ();
+	}
+
+	private String getDataSetFileUploadResults() {
+		return TestFileUtils.getJsonFromFile("nativeFileUploadResponse.json");
+	}
+
+
+}

--- a/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
+++ b/src/test/java/com/researchspace/dataverse/http/DatasetFilePostMockServerTest.java
@@ -63,7 +63,7 @@ public class DatasetFilePostMockServerTest {
 		tss.configure(cfg);
 		Identifier id = new Identifier();
 		id.setId(1234L);
-		DatasetFileList resp = tss.uploadNativeFile(id, null, null);
+		DatasetFileList resp = tss.uploadNativeFile( FileUploadMetadata.builder().build(), id, null, null);
 		assertNotNull(resp.getFiles());
 		assertEquals(1, resp.getFiles().size());
 	}

--- a/src/test/resources/data/json/nativeFileUploadResponse.json
+++ b/src/test/resources/data/json/nativeFileUploadResponse.json
@@ -1,0 +1,38 @@
+{
+  "status": "OK",
+  "message": {
+    "message": "This file has the same content as out198.json that is in the dataset. "
+  },
+  "data": {
+    "files": [
+      {
+        "description": "My description.",
+        "label": "out198-1.json",
+        "restricted": false,
+        "directoryLabel": "data/subdir1",
+        "version": 1,
+        "datasetVersionId": 223100,
+        "categories": [
+          "Data"
+        ],
+        "dataFile": {
+          "id": 2013378,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "out198-1.json",
+          "contentType": "application/json",
+          "filesize": 530,
+          "description": "My description.",
+          "storageIdentifier": "s3://demo-dataverse-org:18496421a60-31b9c8e88499",
+          "rootDataFileId": -1,
+          "md5": "7ac97aa42f2b7f05b0cfc46d28a3f979",
+          "checksum": {
+            "type": "MD5",
+            "value": "7ac97aa42f2b7f05b0cfc46d28a3f979"
+          },
+          "creationDate": "2022-11-20"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
@AleixMT here is a PR of intended changes.
It supports upload of file using native API, not Sword.
Please have a look at the new tests in DatasetOperationsTest such as  `uploadFileToDataSetWithNativeApiBytes` to see how to use it.
Any comments welcome
